### PR TITLE
feat: support batch repository setup with glob patterns

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,11 @@ help: ## Display this help.
 # ------------------------------------------------------------------------------
 #  build
 
+.PHONY: build
+build: ## Build the binary for the current platform.
+	@mkdir -p bin
+	go build -o bin/$(BINNAME) $(GOFLAGS) -trimpath -tags '$(TAGS)' -ldflags '$(LDFLAGS)' ./cmd/gits
+
 # Concat all release paths. (e.g. bin/release/gits-darwin-amd64, etc.)
 ALL_TARGETS := $(foreach plat,$(PLATFORMS),$(foreach arch,$(ARCHES),\
 	$(BINDIR)/$(BINNAME)-$(plat)-$(arch)))

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <!-- vim-markdown-toc GFM -->
 
 - [Features](#features)
+- [Concepts](#concepts)
 - [Install](#install)
 - [Usage](#usage)
 - [Configuration](#configuration)
@@ -19,12 +20,22 @@
 Use as a git clone manager, and while developing on multiple git repositories.
 
 - [x] GitHub/GitLab/Bitbucket/filesystem support with cache
-- [x] Interactive browsing of projects/repositories/branches/tags
+- [x] Interactive browsing of gits projects/repositories/branches/tags
 - [x] Clone/fetch/pull for multiple repositories
 - [x] Show one-line status with icons for all repositories
-- [x] List projects as table/tree/json/name
+- [x] List gits projects as table/tree/json/name
 - [x] Checkout branches interactively
 - [x] Configurable by YAML/JSON/TOML
+
+## Concepts
+
+A **gits project** is a named group of Git repositories managed together by
+`gits`. It is not itself a Git repository or a software build project. Before
+using commands such as `list`, `status`, or `pull`, decide how you want to group
+your repositories into one or more gits projects.
+
+For example, a gits project named `backend` could contain every backend service
+repository, allowing `gits status backend` to check them together.
 
 ## Install
 
@@ -42,39 +53,40 @@ go install github.com/rafi/gits
 
 ## Usage
 
-Usage: `gits [command] <project>`
+Usage: `gits [command] <gits-project>`
 
 Available Commands:
 
-- `add` —      Add repository to a project
+- `add` —      Add repositories to a gits project
 - `browse` —   Browse branches and tags
 - `cd` —       Get repository path
 - `checkout` — Traverse repositories and optionally checkout branch
-- `clone` —    Clone all repositories for specified project(s)
+- `clone` —    Clone all repositories for specified gits project(s)
 - `fetch` —    Fetch and prune from all remotes
 - `help` —     Help about any command
-- `list` —     List all projects or their repositories
+- `list` —     List all gits projects or their repositories
 - `orphan` —   Finds orphan repository
 - `pull` —     Pull repositories
 - `status` —   Shows Git repositories short status
-- `sync` —     Synchronize project caches
+- `sync` —     Synchronize gits project caches
 - `version` —  Shows current version
 
-`gits` is configured by a YAML file. See [examples](#config-examples). `gits`
-will look for a config file at `~/.gits.yaml` or
-`$XDG_CONFIG_HOME/gits/.git.yaml`.
+`gits` stores gits project definitions in a configuration file. See
+[examples](#config-examples). It looks for `~/.gits.yaml` or
+`$XDG_CONFIG_HOME/gits/config.yaml`.
 
-You can run `gits` with project names as arguments, or a local path to a
-directory containing multiple projects.
+You can pass configured gits project names to commands. You can also pass a
+local path to discover the Git repositories beneath it dynamically, without
+creating a permanent gits project.
 
 Examples:
 
 ```bash
 gits                # list all commands
-gits list           # list all projects
-gits list acme      # list all project 'acme' repositories
+gits list           # list all gits projects
+gits list acme      # list repositories in the 'acme' gits project
 
-gits status acme    # show status for project 'acme' repositories
+gits status acme    # show status for repositories in the 'acme' gits project
 gits status ~/code  # show status for all repositories at path
 gits status .       # show status for all repositories at current path
 ```
@@ -90,17 +102,21 @@ gits add acme 'backend*'
 
 Quote glob patterns so `gits` can expand them consistently. Matching paths that
 are not Git repositories are ignored, and repositories already mapped to the
-project are skipped.
+gits project are skipped. If no config file exists, `gits add` creates
+`~/.gits.yaml` automatically.
 
 To use `gits cd` — source [./contrib/cdgit.sh](./contrib/cdgit.sh) in your shell
 `~/.bashrc` or `~/.zshrc`, and use `cdgit` to navigate to a repository.
 
 ## Configuration
 
-Configuration file must be present at `~/.gits.yaml` or `$XDG_CONFIG_HOME/gits/.gits.yaml`.
+Configuration is loaded from `~/.gits.yaml` or
+`$XDG_CONFIG_HOME/gits/config.yaml`. If neither exists, `gits add`
+automatically creates `~/.gits.yaml`.
 
 > [!WARNING]
-> Each project in config file can either have a `source` or `repos` key, not both.
+> Each gits project in the config file can have either a `source` or `repos`
+> key, not both.
 
 The structure of the config file is as follows:
 
@@ -108,9 +124,9 @@ The structure of the config file is as follows:
 ---
 # ~/.gits.yaml
 
-# Project definition
-projectname:          # Project name
-  desc: My projects   # Optional
+# Gits project definition
+projectname:          # Gits project name
+  desc: My repositories # Optional
   path: ~/code/github # Optional if 'repos' are specified and have absolute paths.
   source:             # Required if no 'repos' defined, default: filesystem
     type: github      # Required: github|gitlab|bitbucket|filesystem
@@ -126,7 +142,7 @@ anotherproject:
 
 ## Config Examples
 
-Each project in the following example is defined differently:
+Each gits project in the following example is defined differently:
 
 ```yaml
 ---
@@ -184,7 +200,7 @@ myapp:
   - dir: android
     src: https://github.com/app/android.git
 
-# Absolute directories and explicit remote source URL. (No project path)
+# Absolute directories and explicit remote source URL. (No gits project path)
 rafi:
   desc: My dotfiles
   repos:

--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ gits status ~/code  # show status for all repositories at path
 gits status .       # show status for all repositories at current path
 ```
 
+The `add` command can add the current repository, clone and add a remote
+repository, or add multiple local repositories matched by a glob:
+
+```bash
+gits add acme
+gits add acme https://github.com/acme/api.git
+gits add acme 'backend*'
+```
+
+Quote glob patterns so `gits` can expand them consistently. Matching paths that
+are not Git repositories are ignored, and repositories already mapped to the
+project are skipped.
+
 To use `gits cd` — source [./contrib/cdgit.sh](./contrib/cdgit.sh) in your shell
 `~/.bashrc` or `~/.zshrc`, and use `cdgit` to navigate to a repository.
 

--- a/cmd/gits/all.go
+++ b/cmd/gits/all.go
@@ -24,7 +24,7 @@ import (
 const (
 	appName  = "gits"
 	appShort = "gits is a tool for managing multiple Git repositories"
-	appLong  = `Fast CLI Git manager for multiple repositories grouped by projects, with GitHub/GitLab/Bitbucket support.`
+	appLong  = `Fast CLI Git manager for repositories grouped into gits projects, with GitHub/GitLab/Bitbucket support.`
 )
 
 var listOutput = "table"
@@ -52,7 +52,7 @@ func init() {
 
 var addCmd = &cobra.Command{
 	Use:               "add [project] [repo-or-pattern]...",
-	Short:             "Add repositories to a project",
+	Short:             "Add repositories to a gits project",
 	Args:              cobra.ArbitraryArgs,
 	ValidArgsFunction: completeProject,
 	RunE:              runWithDeps(add.ExecAdd),
@@ -109,7 +109,7 @@ var fetchCmd = &cobra.Command{
 
 var listCmd = &cobra.Command{
 	Use:               "list [project]...",
-	Short:             "List project repositories",
+	Short:             "List gits projects and their repositories",
 	Aliases:           []string{"ls"},
 	Args:              cobra.ArbitraryArgs,
 	ValidArgsFunction: completeProject,
@@ -153,7 +153,7 @@ var statusCmd = &cobra.Command{
 
 var syncCmd = &cobra.Command{
 	Use:               "sync [project]...",
-	Short:             "Synchronize project caches",
+	Short:             "Synchronize gits project caches",
 	Args:              cobra.ArbitraryArgs,
 	ValidArgsFunction: completeProject,
 	RunE:              runWithDeps(sync.ExecSync),

--- a/cmd/gits/all.go
+++ b/cmd/gits/all.go
@@ -51,9 +51,9 @@ func init() {
 }
 
 var addCmd = &cobra.Command{
-	Use:               "add [project] [repo]",
-	Short:             "Add repository to a project",
-	Args:              cobra.MaximumNArgs(2),
+	Use:               "add [project] [repo-or-pattern]...",
+	Short:             "Add repositories to a project",
+	Args:              cobra.ArbitraryArgs,
 	ValidArgsFunction: completeProject,
 	RunE:              runWithDeps(add.ExecAdd),
 }

--- a/internal/cli/add/file.go
+++ b/internal/cli/add/file.go
@@ -3,28 +3,62 @@ package add
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
-// load loads a yaml file into an abstract node.
-func load(filePath string) (yaml.Node, error) {
+// load loads a YAML file into an abstract node. If no config exists, it
+// initializes an empty mapping at the default path without writing it until
+// the add operation succeeds.
+func load(filePath, homeDir string) (yaml.Node, string, bool, error) {
 	var node yaml.Node
-	data, err := os.ReadFile(filePath)
-	if err != nil {
-		return node, err
+	if filePath == "" {
+		filePath = filepath.Join(homeDir, ".gits.yaml")
 	}
-	err = yaml.Unmarshal(data, &node)
-	return node, err
+
+	data, err := os.ReadFile(filePath)
+	created := false
+	initializedEmpty := false
+	switch {
+	case os.IsNotExist(err):
+		data = []byte("{}\n")
+		created = true
+		initializedEmpty = true
+	case err != nil:
+		return node, filePath, false, err
+	case len(strings.TrimSpace(string(data))) == 0:
+		data = []byte("{}\n")
+		initializedEmpty = true
+	}
+
+	if err := yaml.Unmarshal(data, &node); err != nil {
+		return node, filePath, false, err
+	}
+	if len(node.Content) == 0 || node.Content[0].Kind != yaml.MappingNode {
+		return node, filePath, false, fmt.Errorf("config root must be a YAML mapping")
+	}
+	if initializedEmpty {
+		node.Content[0].Style = 0
+	}
+	return node, filePath, created, nil
 }
 
 // save saves a yaml node into a file.
 func save(filePath string, node yaml.Node) error {
-	tmpFile, err := os.CreateTemp("", "gits")
+	configDir := filepath.Dir(filePath)
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		return err
+	}
+
+	tmpFile, err := os.CreateTemp(configDir, ".gits-*")
 	if err != nil {
 		return err
 	}
+	tmpPath := tmpFile.Name()
 	defer tmpFile.Close()
+	defer os.Remove(tmpPath)
 
 	enc := yaml.NewEncoder(tmpFile)
 	enc.SetIndent(2)
@@ -39,7 +73,7 @@ func save(filePath string, node yaml.Node) error {
 		return err
 	}
 
-	return os.Rename(tmpFile.Name(), filePath)
+	return os.Rename(tmpPath, filePath)
 }
 
 // appendProject appends a project node to the root node.

--- a/internal/cli/add/file_test.go
+++ b/internal/cli/add/file_test.go
@@ -1,0 +1,80 @@
+package add
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestLoadInitializesDefaultConfig(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	node, configPath, created, err := load("", homeDir)
+	if err != nil {
+		t.Fatalf("load() error = %v", err)
+	}
+	if !created {
+		t.Error("load() created = false, want true")
+	}
+
+	wantPath := filepath.Join(homeDir, ".gits.yaml")
+	if configPath != wantPath {
+		t.Errorf("load() configPath = %q, want %q", configPath, wantPath)
+	}
+	if len(node.Content) == 0 || node.Content[0].Kind != yaml.MappingNode {
+		t.Fatalf("load() did not return a YAML mapping: %#v", node)
+	}
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Errorf("load() wrote the config before save, stat error = %v", err)
+	}
+}
+
+func TestLoadAcceptsEmptyConfig(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	node, gotPath, created, err := load(configPath, "")
+	if err != nil {
+		t.Fatalf("load() error = %v", err)
+	}
+	if created {
+		t.Error("load() created = true, want false")
+	}
+	if gotPath != configPath {
+		t.Errorf("load() configPath = %q, want %q", gotPath, configPath)
+	}
+	if len(node.Content) == 0 || node.Content[0].Kind != yaml.MappingNode {
+		t.Fatalf("load() did not return a YAML mapping: %#v", node)
+	}
+}
+
+func TestSaveCreatesConfigDirectory(t *testing.T) {
+	t.Parallel()
+
+	homeDir := t.TempDir()
+	node, _, _, err := load("", homeDir)
+	if err != nil {
+		t.Fatalf("load() error = %v", err)
+	}
+	appendProject("backend", node.Content[0])
+
+	configPath := filepath.Join(homeDir, ".config", "gits", "config.yaml")
+	if err := save(configPath, node); err != nil {
+		t.Fatalf("save() error = %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "backend:\n  repos: []\n" {
+		t.Errorf("save() content = %q", data)
+	}
+}

--- a/internal/cli/add/handler.go
+++ b/internal/cli/add/handler.go
@@ -19,8 +19,8 @@ import (
 //   - project name
 //   - repository paths, a glob pattern, or a remote URL
 func ExecAdd(args []string, deps types.RuntimeCLI) error {
-	// Load the config file.
-	rootNode, err := load(deps.ConfigPath)
+	// Load or initialize the config file.
+	rootNode, configPath, configCreated, err := load(deps.ConfigPath, deps.HomeDir)
 	if err != nil {
 		return err
 	}
@@ -70,10 +70,13 @@ func ExecAdd(args []string, deps types.RuntimeCLI) error {
 		return fmt.Errorf("all matched repositories are already in project %q", project.Name)
 	}
 
-	if err := save(deps.ConfigPath, rootNode); err != nil {
+	if err := save(configPath, rootNode); err != nil {
 		return err
 	}
 
+	if configCreated {
+		fmt.Printf("Created config file %q\n", configPath)
+	}
 	if len(addedPaths) == 1 {
 		fmt.Printf("Added %q repository to project %q\n", addedPaths[0], project.Name)
 	} else {

--- a/internal/cli/add/handler.go
+++ b/internal/cli/add/handler.go
@@ -13,10 +13,11 @@ import (
 	"github.com/rafi/gits/internal/types"
 )
 
-// ExecAdd adds the current repository to a project in the config file.
+// ExecAdd adds one or more repositories to a project in the config file.
 //
 // Args: (optional)
 //   - project name
+//   - repository paths, a glob pattern, or a remote URL
 func ExecAdd(args []string, deps types.RuntimeCLI) error {
 	// Load the config file.
 	rootNode, err := load(deps.ConfigPath)
@@ -38,57 +39,99 @@ func ExecAdd(args []string, deps types.RuntimeCLI) error {
 		return err
 	}
 
-	cwd, err := ensureRepository(args, deps)
+	repositoryPaths, err := ensureRepositories(args, deps)
 	if err != nil {
 		return err
 	}
 
-	remoteURL, err := deps.Git.Remote(cwd)
-	if err != nil {
-		return fmt.Errorf("failed adding repo: %w", err)
+	existingPaths := make(map[string]struct{}, len(project.Repos))
+	for _, repo := range project.Repos {
+		existingPaths[filepath.Clean(repo.AbsPath)] = struct{}{}
 	}
 
-	for _, r := range project.Repos {
-		if r.AbsPath == cwd {
-			return fmt.Errorf("repository already in project %q", project.Name)
+	addedPaths := make([]string, 0, len(repositoryPaths))
+	for _, repositoryPath := range repositoryPaths {
+		if _, exists := existingPaths[filepath.Clean(repositoryPath)]; exists {
+			continue
 		}
+
+		remoteURL, err := deps.Git.Remote(repositoryPath)
+		if err != nil {
+			return fmt.Errorf("failed adding repository %q: %w", repositoryPath, err)
+		}
+
+		nicePath := cli.Path(repositoryPath, deps.HomeDir)
+		appendRepo(nicePath, remoteURL, reposNode)
+		addedPaths = append(addedPaths, nicePath)
+		existingPaths[filepath.Clean(repositoryPath)] = struct{}{}
 	}
 
-	nicePath := cli.Path(cwd, deps.HomeDir)
-	appendRepo(nicePath, remoteURL, reposNode)
+	if len(addedPaths) == 0 {
+		return fmt.Errorf("all matched repositories are already in project %q", project.Name)
+	}
 
 	if err := save(deps.ConfigPath, rootNode); err != nil {
 		return err
 	}
 
-	fmt.Printf("Added %q repository to project %q\n", nicePath, project.Name)
+	if len(addedPaths) == 1 {
+		fmt.Printf("Added %q repository to project %q\n", addedPaths[0], project.Name)
+	} else {
+		fmt.Printf("Added %d repositories to project %q\n", len(addedPaths), project.Name)
+		for _, path := range addedPaths {
+			fmt.Printf("  - %s\n", path)
+		}
+	}
 	return nil
 }
 
-// ensureRepository returns the current repository path, and clones it if it
-// doesn't exist.
-func ensureRepository(args []string, deps types.RuntimeCLI) (string, error) {
+// ensureRepositories returns repository paths selected by the arguments. A
+// single argument that is neither a local path nor a glob retains the existing
+// behavior of being cloned as a remote URL.
+func ensureRepositories(args []string, deps types.RuntimeCLI) ([]string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		return "", fmt.Errorf("unable to get current directory: %w", err)
+		return nil, fmt.Errorf("unable to get current directory: %w", err)
 	}
 
-	if len(args) > 1 {
-		// Clone repository if address has been provided.
-		remoteURL := args[1]
+	if len(args) < 2 {
+		if !deps.Git.IsRepo(cwd) {
+			return nil, fmt.Errorf("not a git repository: %s", cwd)
+		}
+		return []string{cwd}, nil
+	}
+
+	targets := args[1:]
+	if len(targets) == 1 && !hasGlobMeta(targets[0]) {
+		path := resolvePath(cwd, targets[0])
+		info, statErr := os.Stat(path)
+		switch {
+		case statErr == nil:
+			if !info.IsDir() || !deps.Git.IsRepo(path) {
+				return nil, fmt.Errorf("not a git repository: %s", path)
+			}
+			return []string{path}, nil
+		case !os.IsNotExist(statErr):
+			return nil, fmt.Errorf("unable to inspect repository %q: %w", path, statErr)
+		}
+
+		// Clone a single target that does not resolve to a local path.
+		remoteURL := targets[0]
 		baseName := strings.TrimSuffix(filepath.Base(remoteURL), ".git")
-		cwd = filepath.Join(cwd, baseName)
-		output, err := deps.Git.Clone(remoteURL, cwd)
+		path = filepath.Join(cwd, baseName)
+		output, err := deps.Git.Clone(remoteURL, path)
 		if err != nil {
 			fmt.Println(output)
-			return "", err
+			return nil, err
 		}
+		return []string{path}, nil
 	}
 
-	if !deps.Git.IsRepo(cwd) {
-		return "", fmt.Errorf("not a git repository: %s", cwd)
+	paths, err := expandRepositoryTargets(cwd, targets, deps.Git.IsRepo)
+	if err != nil {
+		return nil, err
 	}
-	return cwd, nil
+	return paths, nil
 }
 
 // ensureProject returns project by name, and creates it if it doesn't exist.

--- a/internal/cli/add/targets.go
+++ b/internal/cli/add/targets.go
@@ -1,0 +1,63 @@
+package add
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func expandRepositoryTargets(
+	cwd string,
+	targets []string,
+	isRepo func(string) bool,
+) ([]string, error) {
+	paths := make([]string, 0, len(targets))
+	seen := make(map[string]struct{})
+
+	for _, target := range targets {
+		matches := []string{resolvePath(cwd, target)}
+		if hasGlobMeta(target) {
+			var err error
+			matches, err = filepath.Glob(resolvePath(cwd, target))
+			if err != nil {
+				return nil, fmt.Errorf("invalid repository pattern %q: %w", target, err)
+			}
+			if len(matches) == 0 {
+				return nil, fmt.Errorf("repository pattern %q matched no paths", target)
+			}
+		}
+
+		for _, path := range matches {
+			path = filepath.Clean(path)
+			info, err := os.Stat(path)
+			if err != nil {
+				return nil, fmt.Errorf("unable to inspect repository %q: %w", path, err)
+			}
+			if !info.IsDir() || !isRepo(path) {
+				continue
+			}
+			if _, exists := seen[path]; exists {
+				continue
+			}
+			seen[path] = struct{}{}
+			paths = append(paths, path)
+		}
+	}
+
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("no Git repositories matched")
+	}
+	return paths, nil
+}
+
+func resolvePath(cwd, path string) string {
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
+	}
+	return filepath.Join(cwd, path)
+}
+
+func hasGlobMeta(path string) bool {
+	return strings.ContainsAny(path, "*?[")
+}

--- a/internal/cli/add/targets_test.go
+++ b/internal/cli/add/targets_test.go
@@ -1,0 +1,76 @@
+package add
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestExpandRepositoryTargetsGlob(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	for _, name := range []string{"backend-api", "backend-docs", "backend-worker", "frontend"} {
+		if err := os.Mkdir(filepath.Join(cwd, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	isRepo := func(path string) bool {
+		return filepath.Base(path) != "backend-docs"
+	}
+	got, err := expandRepositoryTargets(cwd, []string{"backend*"}, isRepo)
+	if err != nil {
+		t.Fatalf("expandRepositoryTargets() error = %v", err)
+	}
+
+	want := []string{
+		filepath.Join(cwd, "backend-api"),
+		filepath.Join(cwd, "backend-worker"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expandRepositoryTargets() = %v, want %v", got, want)
+	}
+}
+
+func TestExpandRepositoryTargetsExpandedByShell(t *testing.T) {
+	t.Parallel()
+
+	cwd := t.TempDir()
+	for _, name := range []string{"backend-api", "backend-worker"} {
+		if err := os.Mkdir(filepath.Join(cwd, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := expandRepositoryTargets(
+		cwd,
+		[]string{"backend-api", "backend-worker", "backend-api"},
+		func(string) bool { return true },
+	)
+	if err != nil {
+		t.Fatalf("expandRepositoryTargets() error = %v", err)
+	}
+
+	want := []string{
+		filepath.Join(cwd, "backend-api"),
+		filepath.Join(cwd, "backend-worker"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("expandRepositoryTargets() = %v, want %v", got, want)
+	}
+}
+
+func TestExpandRepositoryTargetsNoMatches(t *testing.T) {
+	t.Parallel()
+
+	_, err := expandRepositoryTargets(
+		t.TempDir(),
+		[]string{"backend*"},
+		func(string) bool { return true },
+	)
+	if err == nil {
+		t.Fatal("expandRepositoryTargets() error = nil, want an error")
+	}
+}


### PR DESCRIPTION
- Add make build for compiling the current platform.
- Support adding multiple repositories with gits add <project> '<pattern>'.
- Skip non-Git paths and repositories already mapped.
- Automatically create ~/.gits.yaml when needed.
- Support existing empty configs and nested explicit config paths.
- Clarify the meaning of “gits project” in documentation and CLI help.
- Add tests for glob matching and config initialization.
- Verify with go test ./..., go vet ./..., and make build.